### PR TITLE
fix,enh,ci: update codespell support (config, version) and make it fix few typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,6 @@
 [codespell]
-skip = .git,*.pdf,*.svg,package-lock.json,*.min.js,vendor,.sass-cache,locales,ui-text.yml
-# hsi - server name
-ignore-words-list = keypair,nd,nin,hsi
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,*.svg,package-lock.json,*.css,*.min.*,.codespellrc,vendor,_data,.sass-cache,locales,*.scss
+check-hidden = true
+ignore-regex = \$nin\b
+ignore-words-list = hsi

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,3 +1,4 @@
+# Codespell configuration is within .codespellrc
 ---
 name: Codespell
 
@@ -7,6 +8,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   codespell:
     name: Check for spelling errors
@@ -14,6 +18,6 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Codespell
-        uses: codespell-project/actions-codespell@v1
+        uses: codespell-project/actions-codespell@v2

--- a/api/controllers/resource.js
+++ b/api/controllers/resource.js
@@ -467,7 +467,7 @@ router.get('/usage/:resource_id', common.jwt(), (req, res, next)=>{
         if(err) return next(err);
         if(!resource) return res.status(404).end();
 
-        if(!common.canUseResource(req.user, resource)) return res.status(401).send({messasge: "you can't access this resource"});
+        if(!common.canUseResource(req.user, resource)) return res.status(401).send({message: "you can't access this resource"});
 
         //load usage graph
         //TODO - needs to be switched to use influxdb

--- a/api/controllers/task.js
+++ b/api/controllers/task.js
@@ -514,7 +514,7 @@ router.post('/upload/:taskid', common.jwt(), function(req, res, next) {
                                 pipe.on('close', function() {
                                     console.info("streaming closed");
 
-                                    //this is an undocumented feature to exlode uploade tar.gz
+                                    //this is an undocumented feature to exlode upload tar.gz
                                     if(req.query.untar) {
 
                                         //is this secure enough?
@@ -610,7 +610,7 @@ router.post('/upload2/:taskid', common.jwt(), upload.single('file'), function(re
                                     console.info("streaming closed.. removing uploaded file");
                                     fs.unlinkSync(req.file.path);
 
-                                    //this is an undocumented feature to exlode uploade tar.gz
+                                    //this is an undocumented feature to exlode upload tar.gz
                                     if(req.query.untar) {
                                         console.info("tar xzf-ing");
 

--- a/api/models.js
+++ b/api/models.js
@@ -299,7 +299,7 @@ taskSchema.post('findOneAndRemove', events.task);
 taskSchema.post('remove', events.task);
 
 taskSchema.index({status: 1, _group_id: 1});  //counting number of tasks per group
-taskSchema.index({user_id: 1, _group_id: 1});  //for rule hanler to find task that belongs to a user
+taskSchema.index({user_id: 1, _group_id: 1});  //for rule handler to find task that belongs to a user
 taskSchema.index({'config._outputs.id': 1});  //to look for app-stage that staged specific dataset (dataset.vue) 
 //taskSchema.index({project: 1, removed: 1}); //for task aggregate $math and group by subject/datatype
 //taskSchema.index({ "_group_id": 1, "finish_date": 1, "resource_id": 1, "service": 1, "start_date": 1 }); //total walltime

--- a/bin/serviceinfo.js
+++ b/bin/serviceinfo.js
@@ -119,7 +119,7 @@ db.init(function(err) {
 
         next=>{
             async.eachOfSeries(service_info, (v, k, next_service)=>{
-                console.log("analying average runtime from the most recent 100 finishes for...", k);
+                console.log("analyzing average runtime from the most recent 100 finishes for...", k);
                 db.Taskevent.find({service: k, status: "finished"})
                 .sort('-date').select('date task_id').limit(100).exec((err, finish_events)=>{
                     if(err) return next_service(err);

--- a/bin/task.js
+++ b/bin/task.js
@@ -210,7 +210,7 @@ function handle_housekeeping(task, cb) {
         //I need to be really be sure that the directory is indeed removed before concluding that it is.
         //To do that, we either need to count the number of times it *appears* to be removed, or do something clever.
         //TODO..
-        //I need to solve this.. if task gets removed by resource, we need to mark the task as removed or dependending task
+        //I need to solve this.. if task gets removed by resource, we need to mark the task as removed or depending task
         //will fail! For now, we can make sure that resource won't remove tasks for at least 10 days... Maybe we could make this
         //number configurable for each task?
         next=>{

--- a/ui/config.js.sample
+++ b/ui/config.js.sample
@@ -17,7 +17,7 @@ angular.module('app.config', [])
     progress_api: '../api/progress',
     progress_url: '../progress',
 
-    //authentcation service API to refresh token, etc.
+    //authentication service API to refresh token, etc.
     auth_api: '../api/auth',
     //authentication service URL to jump if user needs to login
     auth_url: '../auth',

--- a/ui/js/app.js
+++ b/ui/js/app.js
@@ -386,7 +386,7 @@ function(appconf, $http, $timeout, toaster) {
             function reload_task() {
                 return $http.get(appconf.api+"/task/"+scope.task._id)
                 .then(function(res) {
-                    //update without chainging parent reference so that change will be visible via workflow
+                    //update without changing parent reference so that change will be visible via workflow
                     for(var k in res.data) {
                         scope.task[k] = res.data[k];
                     } 
@@ -422,7 +422,7 @@ function(appconf, $http, $timeout, toaster) {
                 return $http.put(appconf.api+"/task/rerun/"+scope.task._id)
                 .then(function(res) {
                     toaster.success(res.data.message);
-                    //update without chainging parent reference so that change will be visible via workflow
+                    //update without changing parent reference so that change will be visible via workflow
                     //console.dir(res.data);
                     for(var k in res.data.task) {
                         scope.task[k] = res.data.task[k];

--- a/ui/t/resources.html
+++ b/ui/t/resources.html
@@ -122,7 +122,7 @@
                 <button class="btn btn-xs" ng-click="inst.config.enc_keytab = ''">Reset</button>
             </div>
             <div ng-if="inst.config.enc_keytab !== true">
-                <p class="help-block">Issue your kerbros keytab, then run it with base64 command to genenerate the base64 formatted keytab</p>
+                <p class="help-block">Issue your kerbros keytab, then run it with base64 command to generate the base64 formatted keytab</p>
                 <textarea class="form-control" ng-model="inst.config.enc_keytab" required></textarea>
             </div>
         </div>


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.

Might be fixing 1 functionality bug (in `message` typo)

edit: Apparently `codespell` support was there but nobody cared to react to its errors and run it to fix the typos!  well, I did that now.